### PR TITLE
feat: add gang command, blip filtering and admin tools + Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,144 @@
-# rsg-gangmenu
- 
+<img width="2948" height="497" alt="rsg_framework" src="https://github.com/user-attachments/assets/638791d8-296d-4817-a596-785325c1b83a" />
+
+# 💀 rsg-gangmenu
+**Gang boss management menu for RedM servers using RSG Core.**
+
+![Platform](https://img.shields.io/badge/platform-RedM-darkred)
+![License](https://img.shields.io/badge/license-GPL--3.0-green)
+
+> ox_lib–based context menus for **gang bosses** to manage members, funds, and a shared storage. Uses RSG Core prompts at configured locations, with optional map blips.
+
+---
+
+## 🛠️ Dependencies
+- [**rsg-core**](https://github.com/Rexshack-RedM/rsg-core) 🤠
+- [**ox_lib**](https://github.com/Rexshack-RedM/ox_lib) ⚙️
+- [**oxmysql**](https://github.com/overextended/oxmysql) 🗄️ *(required for gang funds)*
+- [**rsg-inventory**](https://github.com/Rexshack-RedM/rsg-inventory) 🎒 *(for the gang stash)*
+
+**Interaction:** Context prompt at each `Config.GangLocations[i].coords` opens the main menu (uses `exports['rsg-core']:createPrompt`).  
+**Key text:** Prompt displays the configured key from `RSGCore.Shared.Keybinds[Config.Keybind]`.  
+**Locales:** `locales/en.json, fr.json, es.json, it.json, el.json, pt-br.json` (loaded via `lib.locale()`).
+
+**Command:** `/gangmenu` opens the main gang management menu.
+
+---
+
+## ✨ Features (detailed)
+
+### 🧭 Main Menu *(boss only)*
+- **Manage Members**
+  - View the **Member List**.
+  - **Set grade** for a member.
+  - **Fire** a member.
+- **Hire Gang Members**
+  - List **nearby civilians** and recruit them into your gang.
+- **Storage Access**
+  - Open the **shared gang stash** (via `rsg-inventory`), with configurable slots/weight.
+- **Money Management**
+  - View gang **balance** (server callback).
+  - **Deposit** and **Withdraw** funds via input dialogs.
+
+> Access checks use `Player.PlayerData.gang.isboss` on client & server.
+
+### 🗺️ Prompts & Blips
+- For every entry in `Config.GangLocations`, the script:
+  - Creates a **prompt** at `coords` to open the gang menu.
+  - Optionally spawns a **blip** when `showblip = true` with:
+    - `Config.Blip.blipName`
+    - `Config.Blip.blipSprite`
+    - `Config.Blip.blipScale`
+
+### 💰 Gang Funds (SQL-backed)
+- Uses the `management_funds` table with `type = 'gang'`.
+- Server utilities keep an in-memory cache per gang account and **persist** on change.
+- Exposed server events handle **deposit** and **withdraw**, with ox_lib notifications.
+
+---
+
+## 📸 Preview
+<img width="329" height="603" alt="image" src="https://github.com/user-attachments/assets/b07aa137-83bd-4bc8-8685-c09b3c78dcac" />
+
+---
+
+## 📜 Example Config
+
+```lua
+Config = {}
+
+-- blip settings
+Config.Blip = {
+    blipSprite = 'blip_honor_bad', -- Config.Blip.blipSprite
+    blipScale = 0.2 -- Config.Blip.blipScale
+}
+
+-- settings
+Config.Keybind = 'J'
+Config.StorageMaxWeight = 4000000
+Config.StorageMaxSlots = 50
+
+Config.GangLocations = {
+
+    {   -- example
+        id = 'gang1',
+        name = 'Gang Menu',
+        blipname = 'Gang Name',
+        coords = vector3(0, 0, 0),
+        showblip = false,
+        blipforall = false
+    },
+}
+```
+
+---
+
+## 📂 Installation
+1. Place `rsg-gangmenu` inside your `resources` (or `resources/[rsg]`) folder.
+2. Ensure **rsg-core**, **ox_lib**, **rsg-inventory**, and **oxmysql** are installed and started.
+3. **Database:** import `rsg-gangmenu.sql` (creates `management_funds` with `type='gang'`).
+4. Edit `config.lua` (keybind, stash sizes, blip & gang locations).
+5. Add to your `server.cfg`:
+   ```cfg
+   ensure ox_lib
+   ensure rsg-core
+   ensure rsg-inventory
+   ensure rsg-gangmenu
+   ```
+
+---
+
+## 🔐 Permissions
+- **Boss‑only actions:** The menu and all actions are restricted to gang leaders (`Player.PlayerData.gang.isboss`).  
+- **Grade checks:** Server-side logic validates grade when managing members (promote/demote/fire).
+
+---
+
+## 🗄️ SQL
+`rsg-gangmenu.sql` creates (and seeds) the **management_funds** table:
+```sql
+CREATE TABLE IF NOT EXISTS `management_funds` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `job_name` VARCHAR(50) NOT NULL,
+  `amount`  INT(100) NOT NULL,
+  `type` ENUM('boss','gang') NOT NULL DEFAULT 'boss',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `job_name` (`job_name`),
+  KEY `type` (`type`)
+);
+
+-- seed example
+INSERT INTO `management_funds` (`job_name`, `amount`, `type`) VALUES
+('gang1', 0, 'gang');
+```
+
+---
+
+## 🌍 Locales
+Provided in `locales/`: `en`, `fr`, `es`, `it`, `el`, `pt-br`.  
+Loaded via `lib.locale()` on both client and server. Menu text & notifications are fully localized.
+
+---
+
+## 💎 Credits
+- RSG / Rexshack-RedM and contributors
+- Community testers and translators

--- a/config.lua
+++ b/config.lua
@@ -2,7 +2,6 @@ Config = {}
 
 -- blip settings
 Config.Blip = {
-    blipName = 'Gang Menu', -- Config.Blip.blipName
     blipSprite = 'blip_honor_bad', -- Config.Blip.blipSprite
     blipScale = 0.2 -- Config.Blip.blipScale
 }
@@ -17,8 +16,9 @@ Config.GangLocations = {
     {   -- example
         id = 'gang1',
         name = 'Gang Menu',
+        blipname = 'Gang Name',
         coords = vector3(0, 0, 0),
-        showblip = false
+        showblip = false,
+        blipforall = false
     },
-
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -23,7 +23,8 @@
     "cl_21" : "withdraw money from your account",
     "cl_22" : "Available Balance",
     "cl_23" : "Amount",
-    "cl_open" : "Open",
+    "cl_open" : "Open ",
+    "cl_cmd_error" : "You must be a gang boss",
 
     "sv_storage" : "Gang Storage",
     "sv_24" : "gang menu withdraw",
@@ -55,5 +56,10 @@
     "sv_50" : "successfully recruited",
 
 	"sv_51" : "successfully withdrew",
-	"sv_52" : "successfully deposited $"
+    "sv_52" : "successfully deposited $",
+    "sv_admin_remove" : "Player removed from gang",
+    "sv_admin_error" : "Player not found",
+    "sv_admin_noperm" : "You don't have permission",
+    "sv_admin_usage" : "Usage: /removegang [player id] [gang id]",
+    "sv_admin_invalidgangid" : "Invalid Gang ID"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -22,7 +22,8 @@
     "cl_21" : "retirer de l'argent de votre compte",
     "cl_22" : "Solde Disponible",
     "cl_23" : "Montant",
-    "cl_open" : "Ouvrir",
+    "cl_open" : "Ouvrir ",
+    "cl_cmd_error" : "Vous devez être le boss d'un gang",
 
     "sv_storage" : "Stockage du Gang",
     "sv_24" : "retrait du menu de gang",
@@ -54,5 +55,10 @@
     "sv_50" : "recrutement réussi",
 
 	"sv_51" : "retrait effectué avec succès",
-	"sv_52" : "dépôt effectué avec succès $"
+    "sv_52" : "dépôt effectué avec succès $",
+    "sv_admin_remove" : "Joueur retiré du gang",
+    "sv_admin_error" : "Joueur non trouvé",
+    "sv_admin_noperm" : "Vous n'avez pas la permission",
+    "sv_admin_usage" : "Usage: /removegang [id joueur] [id gang]",
+    "sv_admin_invalidgangid" : "Gang ID Invalide"
 }

--- a/server/server.lua
+++ b/server/server.lua
@@ -254,3 +254,26 @@ RSGCore.Functions.CreateCallback('rsg-gangmenu:getplayers', function(source, cb)
         end)
     cb(players)
 end)
+
+-------------------------------------------------------------------------------------------
+-- admin command to remove player from gang
+-------------------------------------------------------------------------------------------
+RSGCore.Commands.Add('removegang', locale('sv_admin_usage'), {{name = 'id', help = 'Player ID'}, {name = 'gang', help = 'Gang ID'}}, false, function(source, args)
+    local src = source
+    local Player = RSGCore.Functions.GetPlayer(tonumber(args[1]))
+    local gang = args[2]
+    
+    if not Player then
+        TriggerClientEvent('ox_lib:notify', src, {title = locale('sv_43'), description = locale('sv_admin_error'), type = 'error', duration = 5000})
+        return
+    end
+    
+    if not RSGCore.Shared.Gangs[gang] then
+        TriggerClientEvent('ox_lib:notify', src, {title = locale('sv_43'), description = locale('sv_admin_invalidgangid'), type = 'error', duration = 5000})
+        return
+    end
+    
+    Player.Functions.SetGang('none', '0')
+    TriggerClientEvent('ox_lib:notify', src, {title = locale('sv_39'), description = locale('sv_admin_remove'), type = 'success', duration = 5000})
+    TriggerClientEvent('ox_lib:notify', Player.PlayerData.source, {title = locale('sv_39'), description = locale('sv_42'), type = 'inform', duration = 7000})
+end, 'admin')


### PR DESCRIPTION
Add /gangmenu command with simplified menu
- Create new command menu with only "Manage Members" and "Hire Members" options
- Implement menu context tracking to prevent returning to full menu from command
- Add locale keys for command error messages (cl_cmd_error)

Implement gang-specific blip visibility
- Add dynamic blip creation system that updates based on player gang membership
- Add blipforall parameter in config to control public/private blip visibility
- Add blipname parameter for customizable blip names per gang
- Create CreateGangBlips() function with automatic refresh on gang changes
- Add gang update event listener for real-time blip updates

Add admin command to remove players from gangs
- Implement /removegang [playerid] [gangid] command with admin permission
- Add server-side validation for player and gang existence
- Add notification system for both admin and affected player
- Add locale keys for admin command messages (sv_admin_*)

Update Config.GangLocations structure
- Include blipforall and blipname parameters for each gang

Maintain backward compatibility
- Keep original blip menu behavior with full 4-option menu
- Preserve all existing functionality for prompts and location-based menus